### PR TITLE
Fix SNAPSHOT version

### DIFF
--- a/52n-inspire-schema/pom.xml
+++ b/52n-inspire-schema/pom.xml
@@ -2,7 +2,7 @@
     <parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
     </parent>
 	<modelVersion>4.0.0</modelVersion>
     <artifactId>52n-inspire-schema</artifactId>

--- a/52n-isotc211-schema/pom.xml
+++ b/52n-isotc211-schema/pom.xml
@@ -2,7 +2,7 @@
     <parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
     </parent>
 	<modelVersion>4.0.0</modelVersion>
     <artifactId>52n-isotc211-schema</artifactId>

--- a/52n-oasis-schema/pom.xml
+++ b/52n-oasis-schema/pom.xml
@@ -2,7 +2,7 @@
     <parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
     </parent>
 	<modelVersion>4.0.0</modelVersion>
     <artifactId>52n-oasis-schema</artifactId>

--- a/52n-ogc-bp-schema/pom.xml
+++ b/52n-ogc-bp-schema/pom.xml
@@ -2,7 +2,7 @@
     <parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>52n-ogc-bp-schema</artifactId>

--- a/52n-ogc-schema/pom.xml
+++ b/52n-ogc-schema/pom.xml
@@ -2,7 +2,7 @@
     <parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>52n-ogc-schema</artifactId>

--- a/52n-portele-schema/pom.xml
+++ b/52n-portele-schema/pom.xml
@@ -2,7 +2,7 @@
     <parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
     </parent>
 	<modelVersion>4.0.0</modelVersion>
     <artifactId>52n-portele-schema</artifactId>

--- a/52n-w3c-schema/pom.xml
+++ b/52n-w3c-schema/pom.xml
@@ -2,7 +2,7 @@
     <parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>52n-w3c-schema</artifactId>

--- a/52n-xml-aixm-v511/pom.xml
+++ b/52n-xml-aixm-v511/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-aixm-v511</artifactId>

--- a/52n-xml-context-v100/pom.xml
+++ b/52n-xml-context-v100/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-context-v100</artifactId>

--- a/52n-xml-csw-v202/pom.xml
+++ b/52n-xml-csw-v202/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-csw-v202</artifactId>

--- a/52n-xml-cv-v022/pom.xml
+++ b/52n-xml-cv-v022/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-cv-v022</artifactId>

--- a/52n-xml-drt-v100/pom.xml
+++ b/52n-xml-drt-v100/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-drt-v100</artifactId>

--- a/52n-xml-em-v020/pom.xml
+++ b/52n-xml-em-v020/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-em-v020</artifactId>

--- a/52n-xml-eml-v001/pom.xml
+++ b/52n-xml-eml-v001/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-eml-v001</artifactId>

--- a/52n-xml-eml-v002/pom.xml
+++ b/52n-xml-eml-v002/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-eml-v002</artifactId>

--- a/52n-xml-filter-v100/pom.xml
+++ b/52n-xml-filter-v100/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-filter-v100</artifactId>

--- a/52n-xml-filter-v110/pom.xml
+++ b/52n-xml-filter-v110/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-filter-v110</artifactId>

--- a/52n-xml-filter-v20/pom.xml
+++ b/52n-xml-filter-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-filter-v20</artifactId>

--- a/52n-xml-gco-v20120713/pom.xml
+++ b/52n-xml-gco-v20120713/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-gco-v20120713</artifactId>

--- a/52n-xml-gmd-v20120713/pom.xml
+++ b/52n-xml-gmd-v20120713/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-gmd-v20120713</artifactId>

--- a/52n-xml-gmi-v01/pom.xml
+++ b/52n-xml-gmi-v01/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-gmi-v01</artifactId>

--- a/52n-xml-gml-v212/pom.xml
+++ b/52n-xml-gml-v212/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-gml-v212</artifactId>

--- a/52n-xml-gml-v311/pom.xml
+++ b/52n-xml-gml-v311/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-gml-v311</artifactId>

--- a/52n-xml-gml-v321/pom.xml
+++ b/52n-xml-gml-v321/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-gml-v321</artifactId>

--- a/52n-xml-gml-v33/pom.xml
+++ b/52n-xml-gml-v33/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-gml-v33</artifactId>

--- a/52n-xml-gmlcov-v10/pom.xml
+++ b/52n-xml-gmlcov-v10/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-gmlcov-v10</artifactId>

--- a/52n-xml-gwml-v22/pom.xml
+++ b/52n-xml-gwml-v22/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
     <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-gwml-v22</artifactId>

--- a/52n-xml-ifoi-v10/pom.xml
+++ b/52n-xml-ifoi-v10/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-ifoi-v10</artifactId>

--- a/52n-xml-inspire-ad-v40/pom.xml
+++ b/52n-xml-inspire-ad-v40/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-ad-v40</artifactId>

--- a/52n-xml-inspire-au-v40/pom.xml
+++ b/52n-xml-inspire-au-v40/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-au-v40</artifactId>

--- a/52n-xml-inspire-base-v33/pom.xml
+++ b/52n-xml-inspire-base-v33/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-base-v33</artifactId>

--- a/52n-xml-inspire-base2-v20/pom.xml
+++ b/52n-xml-inspire-base2-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-base2-v20</artifactId>

--- a/52n-xml-inspire-bu-base-v40/pom.xml
+++ b/52n-xml-inspire-bu-base-v40/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-bu-base-v40</artifactId>

--- a/52n-xml-inspire-cp-v40/pom.xml
+++ b/52n-xml-inspire-cp-v40/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-cp-v40</artifactId>

--- a/52n-xml-inspire-ef-v40/pom.xml
+++ b/52n-xml-inspire-ef-v40/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-ef-v40</artifactId>

--- a/52n-xml-inspire-gn-v40/pom.xml
+++ b/52n-xml-inspire-gn-v40/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-gn-v40</artifactId>

--- a/52n-xml-inspire-net-v40/pom.xml
+++ b/52n-xml-inspire-net-v40/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-net-v40</artifactId>

--- a/52n-xml-inspire-omor-v30/pom.xml
+++ b/52n-xml-inspire-omor-v30/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-omor-v30</artifactId>

--- a/52n-xml-inspire-ompr-v30/pom.xml
+++ b/52n-xml-inspire-ompr-v30/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-ompr-v30</artifactId>

--- a/52n-xml-inspire-omso-v30/pom.xml
+++ b/52n-xml-inspire-omso-v30/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-omso-v30</artifactId>

--- a/52n-xml-inspire-omso-v301/pom.xml
+++ b/52n-xml-inspire-omso-v301/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-omso-v301</artifactId>

--- a/52n-xml-inspire-tn-v40/pom.xml
+++ b/52n-xml-inspire-tn-v40/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-inspire-tn-v40</artifactId>

--- a/52n-xml-kml-v220/pom.xml
+++ b/52n-xml-kml-v220/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-kml-v220</artifactId>

--- a/52n-xml-om-v100/pom.xml
+++ b/52n-xml-om-v100/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-om-v100</artifactId>

--- a/52n-xml-om-v20/pom.xml
+++ b/52n-xml-om-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-om-v20</artifactId>

--- a/52n-xml-ows-v100/pom.xml
+++ b/52n-xml-ows-v100/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-ows-v100</artifactId>

--- a/52n-xml-ows-v110/pom.xml
+++ b/52n-xml-ows-v110/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-ows-v110</artifactId>

--- a/52n-xml-ows-v20/pom.xml
+++ b/52n-xml-ows-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-ows-v20</artifactId>

--- a/52n-xml-portele/pom.xml
+++ b/52n-xml-portele/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	 <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-portele</artifactId>

--- a/52n-xml-pubsub-v10/pom.xml
+++ b/52n-xml-pubsub-v10/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-pubsub-v10</artifactId>

--- a/52n-xml-rim-v300/pom.xml
+++ b/52n-xml-rim-v300/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>52n-xml-rim-v300</artifactId>

--- a/52n-xml-sampling-v100/pom.xml
+++ b/52n-xml-sampling-v100/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sampling-v100</artifactId>

--- a/52n-xml-sampling-v20/pom.xml
+++ b/52n-xml-sampling-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sampling-v20</artifactId>

--- a/52n-xml-sensorML-v100/pom.xml
+++ b/52n-xml-sensorML-v100/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sensorML-v100</artifactId>

--- a/52n-xml-sensorML-v101/pom.xml
+++ b/52n-xml-sensorML-v101/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sensorML-v101</artifactId>

--- a/52n-xml-sensorML-v20/pom.xml
+++ b/52n-xml-sensorML-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sensorML-v20</artifactId>

--- a/52n-xml-ses-v00/pom.xml
+++ b/52n-xml-ses-v00/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-ses-v00</artifactId>

--- a/52n-xml-sir-v032/pom.xml
+++ b/52n-xml-sir-v032/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>52n-xml-sir-v032</artifactId>

--- a/52n-xml-sld-v100/pom.xml
+++ b/52n-xml-sld-v100/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sld-v100</artifactId>

--- a/52n-xml-sld-v110/pom.xml
+++ b/52n-xml-sld-v110/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sld-v110</artifactId>

--- a/52n-xml-soap-v12/pom.xml
+++ b/52n-xml-soap-v12/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-soap-v12</artifactId>

--- a/52n-xml-sor-v031/pom.xml
+++ b/52n-xml-sor-v031/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>52n-xml-sor-v031</artifactId>

--- a/52n-xml-sos-v100/pom.xml
+++ b/52n-xml-sos-v100/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sos-v100</artifactId>

--- a/52n-xml-sos-v20/pom.xml
+++ b/52n-xml-sos-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sos-v20</artifactId>

--- a/52n-xml-sosdo-v10/pom.xml
+++ b/52n-xml-sosdo-v10/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sosdo-v10</artifactId>

--- a/52n-xml-sosdo-v20/pom.xml
+++ b/52n-xml-sosdo-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sosdo-v20</artifactId>

--- a/52n-xml-sosgda-v10/pom.xml
+++ b/52n-xml-sosgda-v10/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sosgda-v10</artifactId>

--- a/52n-xml-sosgda-v20/pom.xml
+++ b/52n-xml-sosgda-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sosgda-v20</artifactId>

--- a/52n-xml-sosrf-v10/pom.xml
+++ b/52n-xml-sosrf-v10/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sosrf-v10</artifactId>

--- a/52n-xml-sosro-v10/pom.xml
+++ b/52n-xml-sosro-v10/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sosro-v10</artifactId>

--- a/52n-xml-sossf-v10/pom.xml
+++ b/52n-xml-sossf-v10/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sossf-v10</artifactId>

--- a/52n-xml-sps-v100/pom.xml
+++ b/52n-xml-sps-v100/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sps-v100</artifactId>

--- a/52n-xml-sps-v20/pom.xml
+++ b/52n-xml-sps-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sps-v20</artifactId>

--- a/52n-xml-sweCommon-v100/pom.xml
+++ b/52n-xml-sweCommon-v100/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sweCommon-v100</artifactId>

--- a/52n-xml-sweCommon-v101/pom.xml
+++ b/52n-xml-sweCommon-v101/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sweCommon-v101</artifactId>

--- a/52n-xml-sweCommon-v20/pom.xml
+++ b/52n-xml-sweCommon-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-sweCommon-v20</artifactId>

--- a/52n-xml-swes-v20/pom.xml
+++ b/52n-xml-swes-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-swes-v20</artifactId>

--- a/52n-xml-timeseriesML-v10/pom.xml
+++ b/52n-xml-timeseriesML-v10/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-timeseriesML-v10</artifactId>

--- a/52n-xml-urt-v100/pom.xml
+++ b/52n-xml-urt-v100/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.n52.sensorweb</groupId>
         <artifactId>52n-common-xml</artifactId>
-        <version>2.5.0-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>52n-xml-urt-v100</artifactId>

--- a/52n-xml-waterML-dr-v20/pom.xml
+++ b/52n-xml-waterML-dr-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-waterML-dr-v20</artifactId>

--- a/52n-xml-waterML-v20/pom.xml
+++ b/52n-xml-waterML-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-waterML-v20</artifactId>

--- a/52n-xml-wcs-v11/pom.xml
+++ b/52n-xml-wcs-v11/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-wcs-v11</artifactId>

--- a/52n-xml-wfs-v110/pom.xml
+++ b/52n-xml-wfs-v110/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-wfs-v110</artifactId>

--- a/52n-xml-wfs-v20/pom.xml
+++ b/52n-xml-wfs-v20/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-wfs-v20</artifactId>

--- a/52n-xml-wms-v130/pom.xml
+++ b/52n-xml-wms-v130/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-wms-v130</artifactId>

--- a/52n-xml-wns-v0.0.9/pom.xml
+++ b/52n-xml-wns-v0.0.9/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-wns-v009</artifactId>

--- a/52n-xml-wps-v100/pom.xml
+++ b/52n-xml-wps-v100/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>52n-xml-wps-v100</artifactId>

--- a/52n-xml-wps-v20/pom.xml
+++ b/52n-xml-wps-v20/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.n52.wps</groupId>
 	<artifactId>52n-xml-wps-v20</artifactId>

--- a/52n-xml-wrs-v101/pom.xml
+++ b/52n-xml-wrs-v101/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>52n-xml-wrs-v101</artifactId>

--- a/52n-xml-wsa-v10/pom.xml
+++ b/52n-xml-wsa-v10/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-wsa-v10</artifactId>

--- a/52n-xml-wsn-v13/pom.xml
+++ b/52n-xml-wsn-v13/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-wsn-v13</artifactId>

--- a/52n-xml-wsrf-v12/pom.xml
+++ b/52n-xml-wsrf-v12/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.n52.sensorweb</groupId>
 	<artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>52n-xml-wsrf-v12</artifactId>

--- a/52n-xml-xlink-v110/pom.xml
+++ b/52n-xml-xlink-v110/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.n52.sensorweb</groupId>
 		<artifactId>52n-common-xml</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>52n-xml-xlink-v110</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.n52.sensorweb</groupId>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>52n-common-xml</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>52North XML Schema Bindings</name>
     <description>


### PR DESCRIPTION
The next SNAPSHOT version is 2.6.0-SNAPSTHOT and not 2.5.0-SNAPSHOT as the 2.5.0 version was release in April 2018